### PR TITLE
Fix HasRole trait in Laravel 5.2

### DIFF
--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -63,7 +63,7 @@ trait HasRole
         $operator = is_null($operator) ? $this->parseOperator($slug) : $operator;
 
         $roles = $this->getRoles();
-        $roles = (array) $roles;
+        $roles = $roles instanceof \Illuminate\Contracts\Support\Arrayable ? $roles->toArray() : (array) $roles;
         $slug = $this->hasDelimiterToArray($slug);
 
         // array of slugs


### PR DESCRIPTION
Fix for 'in_array() expects parameter 2 to be array, object given'
